### PR TITLE
Bugfix: ,\n in author list

### DIFF
--- a/parserscrapers_plugins/bibtex.py
+++ b/parserscrapers_plugins/bibtex.py
@@ -114,7 +114,7 @@ class BibTexParser(object):
                     d[key] = self.add_val(val)
             elif inkey:
                 # if this line continues the value from a previous line, append
-                inval += kv
+                inval += ',' + kv
                 # if it looks like this line finishes the value, store it and clear for next loop
                 if ( inval.startswith('{') and inval.endswith('}') ) or ( inval.startswith('"') and inval.endswith('"') ):
                     d[inkey] = self.add_val(inval)


### PR DESCRIPTION
Hi,

First of all, many thanks for your bibtex parser, it's awesome and I use it for my own project.

Nevertheless, I found a bug.

Consider the following bibtex snippet
```
 @ARTICLE{Vigil1994,
author = {Vigil, Gene and Xu, Zhenghe and Steinberg, Suzi and Israelachvili,
 Jacob},
title = {Interactions of Silica Surfaces},
journal = {Journal of Colloid and Interface Science},
year = {1994},
volume = {165},
pages = {367--385},
}
```
The parser fails. The last author name is 'IsraelachviliJacob'. The coma is gone.

This is because in line 96, ',\n' is splitted
```python
kvs = [i.strip() for i in record.split(',\n')]
```
I suggest to add the coma back in the case 'inkey' because we know that in such case, the comma was not a separator, but a real coma.

François.