### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Quick Links
 ===========
 
 * Code: http://github.com/okfn/bibserver
-* Documentation: http://bibserver.readthedocs.org/
+* Documentation: https://bibserver.readthedocs.io/
 * Mailing list: http://lists.okfn.org/mailman/listinfo/openbiblio-dev
 
 
@@ -25,7 +25,7 @@ Installation
 ============
 
 See doc/install.rst or
-http://bibserver.readthedocs.org/en/latest/install.html
+https://bibserver.readthedocs.io/en/latest/install.html
 
 
 Command Line Usage

--- a/bibserver/templates/account/view.html
+++ b/bibserver/templates/account/view.html
@@ -41,7 +41,7 @@ jQuery(document).ready(function() {
             <p><br />Your api_key is:</p>
             <p><input type="text" value="{{account['api_key']}}" class="span4 selectable" /></p>
             <p>You need to append this to your API calls if you want to make changes. 
-            <a href="http://bibserver.readthedocs.org/en/latest/api.html">Check out the docs</a> to learn more.</p>
+            <a href="https://bibserver.readthedocs.io/en/latest/api.html">Check out the docs</a> to learn more.</p>
             {% if superuser %}
                 <p>You are the superuser! You can view and edit anything!
                 <br />Be careful...</p>

--- a/bibserver/templates/home/faq.html
+++ b/bibserver/templates/home/faq.html
@@ -36,7 +36,7 @@
         <p>This service is an example of the BibServer software. Please use the following resources to find more information.</p>
 
         <ul>
-        <li><a href="http://bibserver.readthedocs.org">The documentation</a></li>
+        <li><a href="https://bibserver.readthedocs.io">The documentation</a></li>
         <li><a href="http://bibjson.org">BibJSON - the raw data you can get out of BibSoup</a></li>
         <li><a href="http://bibserver.org">The software website</a></li>
         <li><a href="http://github.com/okfn/bibserver">The software repository</a></li>

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -42,7 +42,7 @@ Simple Setup
 .. _ElasticSearch: http://www.elasticsearch.org/
 
 
-See doc/deploy.rst or http://bibserver.readthedocs.org/en/latest/deploy.html
+See doc/deploy.rst or https://bibserver.readthedocs.io/en/latest/deploy.html
 for more details on a full installation
 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.